### PR TITLE
Merge digests function exposed. 

### DIFF
--- a/polars_tdigest/__init__.py
+++ b/polars_tdigest/__init__.py
@@ -52,3 +52,12 @@ def tdigest_cast(expr: IntoExpr) -> pl.Expr:
         is_elementwise=False,
         returns_scalar=True,
     )
+
+def merge_tdigests(expr: IntoExpr) -> pl.Expr:
+    return register_plugin_function(
+        plugin_path=Path(__file__).parent,
+        function_name="merge_tdigests",
+        args=expr,
+        is_elementwise=False,
+        returns_scalar=True,
+    )


### PR DESCRIPTION
While aggregating data frames with t-digest columns it is required that those columns can be merged for further percentile evaluation on the grouped data frame. The use-cases may vary, including storage of pre-aggregated data frames for the analysis and further grouping. 