### PR TITLE
Don't return NaN values for empty clusters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "polars-tdigest"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "jemallocator",
  "ordered-float 4.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-tdigest"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ Install [Rust](https://rustup.rs/).
 
 In order to build the package, please run `maturin develop`. If you want to test performance, run `maturin develop --release`. 
 
+## Developing using cargo
+
+Cargo commands (e.g. `cargo build`, `cargo test`) don't work out of the box. 
+In order to use cargo instead of maturin for local development, remove `extension-module` from `cargo.toml`: 
+replace 
+```
+pyo3 = { version = "0.21.2", features = ["extension-module", "abi3-py38"] }
+```
+with 
+
+```
+pyo3 = { version = "0.21.2", features = ["abi3-py38"] }
+```
+
 ## Commit / Release
 
 Before committing and pushing your work, make sure to run


### PR DESCRIPTION
When there is no data to compute `TDigest`, `TDigest::default` is returned. This struct contains `NaN`s. 
When this value is sent back to polars during reduction step, it's not deserialized properly and rust code panics. 
This is a minimal fix. Later error handling should be improved to turn panic into a proper error